### PR TITLE
Add GPU support for YOLO detector

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,9 @@ DI=10
 # Model/algorithm to use for vehicle detection (options: yolo, tfoda, haarcascade)
 DETECTOR="yolo"
 
+# Enable GPU acceleration to get better performance
+ENABLE_GPU_ACCELERATION=False
+
 # Algorithm to use for vehicle tracking (options: kcf, csrt)
 TRACKER="kcf"
 
@@ -51,15 +54,16 @@ HAAR_CASCADE_PATH="./data/detectors/haarcascade/car.xml"
 # Configs for TFODA (Tensorflow Object Detection API) detector
 TFODA_WEIGHTS_PATH="./data/detectors/tfoda/faster_rcnn_inception_v2_coco_2018_01_28.pb"
 TFODA_CONFIG_PATH="./data/detectors/tfoda/faster_rcnn_inception_v2_coco_2018_01_28.pbtxt"
-TFODA_CLASSES_PATH="./data/detectors/classes.txt"
-TFODA_CLASSES_OF_INTEREST_PATH="./data/detectors/classes_of_interest.txt"
+TFODA_CLASSES_PATH="./data/detectors/coco_classes.txt"
+TFODA_CLASSES_OF_INTEREST_PATH="./data/detectors/coco_classes_of_interest.txt"
 TFODA_CONFIDENCE_THRESHOLD=0.2
 
 # Configs for YOLO (You Only Look Once) detector
 YOLO_WEIGHTS_PATH="./data/detectors/yolo/yolov3.weights"
 YOLO_CONFIG_PATH="./data/detectors/yolo/yolov3.cfg"
-YOLO_CLASSES_PATH="./data/detectors/classes.txt"
-YOLO_CLASSES_OF_INTEREST_PATH="./data/detectors/classes_of_interest.txt"
+YOLO_CLASSES_PATH="./data/detectors/coco_classes.txt"
+YOLO_CLASSES_OF_INTEREST_PATH="./data/detectors/coco_classes_of_interest.txt"
+YOLO_DATA_PATH="./data/detectors/coco.data"
 YOLO_CONFIDENCE_THRESHOLD=0.5
 
 # Log destinations

--- a/VehicleCounter.py
+++ b/VehicleCounter.py
@@ -16,7 +16,7 @@ class VehicleCounter():
         self.frame = initial_frame # current frame of video
         self.detector = detector
         self.tracker = tracker
-        self.droi =  droi # detection region of interest
+        self.droi = droi # detection region of interest
         self.show_droi = show_droi
         self.mcdf = mcdf # maximum consecutive detection failures
         self.mctf = mctf # maximum consecutive tracking failures

--- a/VehicleCounter.py
+++ b/VehicleCounter.py
@@ -50,7 +50,7 @@ class VehicleCounter():
                 blob.update(box)
                 logger.debug('Vehicle tracker updated.', extra={
                     'meta': {
-                        'cat': 'TRACKER_UPDATE',
+                        'label': 'TRACKER_UPDATE',
                         'vehicle_id': _id,
                         'bounding_box': blob.bounding_box,
                         'centroid': blob.centroid,
@@ -73,7 +73,7 @@ class VehicleCounter():
 
                     logger.info('Vehicle counted.', extra={
                         'meta': {
-                            'cat': 'VEHICLE_COUNT',
+                            'label': 'VEHICLE_COUNT',
                             'id': _id,
                             'type': blob.type,
                             'counting_line': label,
@@ -100,7 +100,7 @@ class VehicleCounter():
 
         self.processing_frame_rate = round(cv2.getTickFrequency() / (cv2.getTickCount() - _timer), 2)
         logger.debug('Processing frame rate updated.', extra={
-            'meta': {'cat': 'PROCESSING_SPEED', 'frame_rate': self.processing_frame_rate},
+            'meta': {'label': 'PROCESSING_SPEED', 'frame_rate': self.processing_frame_rate},
         })
 
     def visualize(self):

--- a/main.py
+++ b/main.py
@@ -28,7 +28,7 @@ def run():
     if not cap.isOpened():
         logger.error('Error capturing video. Invalid source.', extra={
             'meta': {
-                'cat': 'VIDEO_CAPTURE',
+                'label': 'VIDEO_CAPTURE',
                 'source': video,
             },
         })
@@ -64,7 +64,7 @@ def run():
 
     logger.info('Processing started.', extra={
         'meta': {
-            'cat': 'COUNT_PROCESS',
+            'label': 'COUNT_PROCESS',
             'counter_config': {
                 'di': detection_interval,
                 'mcdf': mcdf,
@@ -92,11 +92,11 @@ def run():
         k = cv2.waitKey(1) & 0xFF
         if k == ord('p'): # pause/play loop if 'p' key is pressed
             is_paused = False if is_paused else True
-            logger.info('Loop paused/played.', extra={'meta': {'cat': 'COUNT_PROCESS', 'is_paused': is_paused}})
+            logger.info('Loop paused/played.', extra={'meta': {'label': 'COUNT_PROCESS', 'is_paused': is_paused}})
         if k == ord('s') and output_frame is not None: # save frame if 's' key is pressed
             take_screenshot(output_frame)
         if k == ord('q'): # end video loop if 'q' key is pressed
-            logger.info('Loop stopped.', extra={'meta': {'cat': 'COUNT_PROCESS'}})
+            logger.info('Loop stopped.', extra={'meta': {'label': 'COUNT_PROCESS'}})
             break
 
         if is_paused:
@@ -123,7 +123,7 @@ def run():
         cv2.destroyAllWindows()
     if record:
         output_video.release()
-    logger.info('Processing ended.', extra={'meta': {'cat': 'COUNT_PROCESS'}})
+    logger.info('Processing ended.', extra={'meta': {'label': 'COUNT_PROCESS'}})
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -27,10 +27,7 @@ def run():
     cap = cv2.VideoCapture(video)
     if not cap.isOpened():
         logger.error('Error capturing video. Invalid source.', extra={
-            'meta': {
-                'label': 'VIDEO_CAPTURE',
-                'source': video,
-            },
+            'meta': {'label': 'VIDEO_CAPTURE', 'source': video},
         })
         sys.exit(0)
     ret, frame = cap.read()
@@ -64,7 +61,7 @@ def run():
 
     logger.info('Processing started.', extra={
         'meta': {
-            'label': 'COUNT_PROCESS',
+            'label': 'START_PROCESS',
             'counter_config': {
                 'di': detection_interval,
                 'mcdf': mcdf,
@@ -92,11 +89,11 @@ def run():
         k = cv2.waitKey(1) & 0xFF
         if k == ord('p'): # pause/play loop if 'p' key is pressed
             is_paused = False if is_paused else True
-            logger.info('Loop paused/played.', extra={'meta': {'label': 'COUNT_PROCESS', 'is_paused': is_paused}})
+            logger.info('Loop paused/played.', extra={'meta': {'label': 'PAUSE_PLAY_LOOP', 'is_paused': is_paused}})
         if k == ord('s') and output_frame is not None: # save frame if 's' key is pressed
             take_screenshot(output_frame)
         if k == ord('q'): # end video loop if 'q' key is pressed
-            logger.info('Loop stopped.', extra={'meta': {'label': 'COUNT_PROCESS'}})
+            logger.info('Loop stopped.', extra={'meta': {'label': 'STOP_LOOP'}})
             break
 
         if is_paused:
@@ -138,7 +135,7 @@ def run():
         cv2.destroyAllWindows()
     if record:
         output_video.release()
-    logger.info('Processing ended.', extra={'meta': {'label': 'COUNT_PROCESS'}})
+    logger.info('Processing ended.', extra={'meta': {'label': 'END_PROCESS'}})
 
 
 if __name__ == '__main__':

--- a/main.py
+++ b/main.py
@@ -79,9 +79,10 @@ def run():
         },
     })
 
-    # capture mouse events in the debug window
-    cv2.namedWindow('Debug')
-    cv2.setMouseCallback('Debug', mouse_callback, {'frame_width': f_width, 'frame_height': f_height})
+    if not headless:
+        # capture mouse events in the debug window
+        cv2.namedWindow('Debug')
+        cv2.setMouseCallback('Debug', mouse_callback, {'frame_width': f_width, 'frame_height': f_height})
 
     is_paused = False
     output_frame = None

--- a/main.py
+++ b/main.py
@@ -103,6 +103,8 @@ def run():
             time.sleep(0.5)
             continue
 
+        _timer = cv2.getTickCount() # set timer to calculate processing frame rate
+
         if ret:
             vehicle_counter.count(frame)
             output_frame = vehicle_counter.visualize()
@@ -114,6 +116,19 @@ def run():
                 debug_window_size = ast.literal_eval(os.getenv('DEBUG_WINDOW_SIZE'))
                 resized_frame = cv2.resize(output_frame, debug_window_size)
                 cv2.imshow('Debug', resized_frame)
+
+        processing_frame_rate = round(cv2.getTickFrequency() / (cv2.getTickCount() - _timer), 2)
+        frames_processed = round(cap.get(cv2.CAP_PROP_POS_FRAMES))
+        frames_count = round(cap.get(cv2.CAP_PROP_FRAME_COUNT))
+        logger.debug('Frame processed.', extra={
+            'meta': {
+                'label': 'FRAME_PROCESS',
+                'frames_processed': frames_processed,
+                'frame_rate': processing_frame_rate,
+                'frames_left': frames_count - frames_processed,
+                'percentage_processed': round((frames_processed / frames_count) * 100, 2),
+            },
+        })
 
         ret, frame = cap.read()
 

--- a/tracker.py
+++ b/tracker.py
@@ -72,7 +72,7 @@ def add_new_blobs(boxes, classes, confidences, blobs, frame, tracker, mcdf):
 
                 logger.debug('Blob updated.', extra={
                     'meta': {
-                        'label': 'BLOB_UPSERT',
+                        'label': 'BLOB_UPDATE',
                         'vehicle_id': _id,
                         'bounding_box': blob.bounding_box,
                         'type': blob.type,
@@ -89,7 +89,7 @@ def add_new_blobs(boxes, classes, confidences, blobs, frame, tracker, mcdf):
 
             logger.debug('Blob created.', extra={
                 'meta': {
-                    'label': 'BLOB_UPSERT',
+                    'label': 'BLOB_CREATE',
                     'vehicle_id': blob_id,
                     'bounding_box': _blob.bounding_box,
                     'type': _blob.type,

--- a/tracker.py
+++ b/tracker.py
@@ -12,17 +12,17 @@ from util.logger import get_logger
 
 logger = get_logger()
 
-def csrt_create(bounding_box, frame):
+def _csrt_create(bounding_box, frame):
     '''
-    Creates an OpenCV CSRT Tracker object.
+    Create an OpenCV CSRT Tracker object.
     '''
     tracker = cv2.TrackerCSRT_create()
     tracker.init(frame, tuple(bounding_box))
     return tracker
 
-def kcf_create(bounding_box, frame):
+def _kcf_create(bounding_box, frame):
     '''
-    Creates an OpenCV KCF Tracker object.
+    Create an OpenCV KCF Tracker object.
     '''
     tracker = cv2.TrackerKCF_create()
     tracker.init(frame, tuple(bounding_box))
@@ -30,19 +30,19 @@ def kcf_create(bounding_box, frame):
 
 def get_tracker(algorithm, bounding_box, frame):
     '''
-    Fetches a tracker object based on the algorithm specified.
+    Fetch a tracker object based on the algorithm specified.
     '''
     if algorithm == 'csrt':
-        return csrt_create(bounding_box, frame)
+        return _csrt_create(bounding_box, frame)
     if algorithm == 'kcf':
-        return kcf_create(bounding_box, frame)
-    logger.error('Invalid tracking algorithm specified (options: csrt, kcf)', extra={
+        return _kcf_create(bounding_box, frame)
+    logger.error('Invalid tracking algorithm specified (options: csrt, kcf, dlib)', extra={
         'meta': {'label': 'TRACKER_CREATE'},
     })
 
-def remove_stray_blobs(blobs, matched_blob_ids, mcdf):
+def _remove_stray_blobs(blobs, matched_blob_ids, mcdf):
     '''
-    Removes blobs that "hang" after a tracked object has left the frame.
+    Remove blobs that "hang" after a tracked object has left the frame.
     '''
     for _id, blob in list(blobs.items()):
         if _id not in matched_blob_ids:
@@ -53,7 +53,7 @@ def remove_stray_blobs(blobs, matched_blob_ids, mcdf):
 
 def add_new_blobs(boxes, classes, confidences, blobs, frame, tracker, mcdf):
     '''
-    Adds new blobs or updates existing ones.
+    Add new blobs or updates existing ones.
     '''
     matched_blob_ids = []
     for i, box in enumerate(boxes):
@@ -98,12 +98,12 @@ def add_new_blobs(boxes, classes, confidences, blobs, frame, tracker, mcdf):
                 },
             })
 
-    blobs = remove_stray_blobs(blobs, matched_blob_ids, mcdf)
+    blobs = _remove_stray_blobs(blobs, matched_blob_ids, mcdf)
     return blobs
 
 def remove_duplicates(blobs):
     '''
-    Removes duplicate blobs i.e blobs that point to an already detected and tracked vehicle.
+    Remove duplicate blobs i.e blobs that point to an already detected and tracked vehicle.
     '''
     for _id, blob_a in list(blobs.items()):
         for _, blob_b in list(blobs.items()):

--- a/tracker.py
+++ b/tracker.py
@@ -37,7 +37,7 @@ def get_tracker(algorithm, bounding_box, frame):
     if algorithm == 'kcf':
         return kcf_create(bounding_box, frame)
     logger.error('Invalid tracking algorithm specified (options: csrt, kcf)', extra={
-        'meta': {'cat': 'TRACKER_CREATE'},
+        'meta': {'label': 'TRACKER_CREATE'},
     })
 
 def remove_stray_blobs(blobs, matched_blob_ids, mcdf):
@@ -72,7 +72,7 @@ def add_new_blobs(boxes, classes, confidences, blobs, frame, tracker, mcdf):
 
                 logger.debug('Blob updated.', extra={
                     'meta': {
-                        'cat': 'BLOB_UPSERT',
+                        'label': 'BLOB_UPSERT',
                         'vehicle_id': _id,
                         'bounding_box': blob.bounding_box,
                         'type': blob.type,
@@ -89,7 +89,7 @@ def add_new_blobs(boxes, classes, confidences, blobs, frame, tracker, mcdf):
 
             logger.debug('Blob created.', extra={
                 'meta': {
-                    'cat': 'BLOB_UPSERT',
+                    'label': 'BLOB_UPSERT',
                     'vehicle_id': blob_id,
                     'bounding_box': _blob.bounding_box,
                     'type': _blob.type,

--- a/util/debugger.py
+++ b/util/debugger.py
@@ -26,4 +26,4 @@ def capture_pixel_position(window_x, window_y, frame_w, frame_h):
     debug_window_size = ast.literal_eval(os.getenv('DEBUG_WINDOW_SIZE'))
     x = round((frame_w / debug_window_size[0]) * window_x)
     y = round((frame_h / debug_window_size[1]) * window_y)
-    logger.info('Pixel position captured.', extra={'meta': {'cat': 'DEBUG', 'position': (x, y)}})
+    logger.info('Pixel position captured.', extra={'meta': {'label': 'DEBUG', 'position': (x, y)}})

--- a/util/debugger.py
+++ b/util/debugger.py
@@ -26,4 +26,4 @@ def capture_pixel_position(window_x, window_y, frame_w, frame_h):
     debug_window_size = ast.literal_eval(os.getenv('DEBUG_WINDOW_SIZE'))
     x = round((frame_w / debug_window_size[0]) * window_x)
     y = round((frame_h / debug_window_size[1]) * window_y)
-    logger.info('Pixel position captured.', extra={'meta': {'label': 'DEBUG', 'position': (x, y)}})
+    logger.info('Pixel position captured.', extra={'meta': {'label': 'PIXEL_POSITION', 'position': (x, y)}})

--- a/util/image.py
+++ b/util/image.py
@@ -20,7 +20,7 @@ def take_screenshot(frame):
 
     logger.info('Screenshot captured.', extra={
         'meta': {
-            'cat': 'SCREENSHOT_CAPTURE',
+            'label': 'SCREENSHOT_CAPTURE',
             'path': screenshot_path,
         },
     })

--- a/util/image.py
+++ b/util/image.py
@@ -19,10 +19,7 @@ def take_screenshot(frame):
     cv2.imwrite(screenshot_path, frame, [cv2.IMWRITE_JPEG_QUALITY, 80])
 
     logger.info('Screenshot captured.', extra={
-        'meta': {
-            'label': 'SCREENSHOT_CAPTURE',
-            'path': screenshot_path,
-        },
+        'meta': {'label': 'SCREENSHOT_CAPTURE', 'path': screenshot_path},
     })
 
 def get_base64_image(image):


### PR DESCRIPTION
You can now run your YOLO object detection models on GPU to get perf improvements in VCS processing speed.

Changes to make:
- Install GPU version of Python wrapper for Darknet `pip install yolo34py-gpu` (you need an Nvidia GPU with CUDA installed and `CUDA_HOME` env var set)
- Set `ENABLE_GPU_ACCELERATION` env var to `True`
- Set `YOLO_DATA_PATH` to point to the data file for your model e.g [coco.data](https://raw.githubusercontent.com/pjreddie/darknet/master/cfg/coco.data) (edit `names` prop to point to your [classes list](https://raw.githubusercontent.com/pjreddie/darknet/master/data/coco.names))