### PR TITLE
Use joblib to run tracker updates in parallel

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ pytest==5.1.3
 pytest-cov==2.7.1
 pylint==2.3.1
 python-json-logger==0.1.11
+joblib==0.14.1


### PR DESCRIPTION
This is a performance improvement for the multi-tracker. Prior to this change, vehicle trackers were updated sequentially. Since the tracker update process is computationally expensive, it was a huge bottleneck especially when there are several vehicles to be updated.

This PR employs threads via the joblib library to make tracker updates faster. You should be able to observe the speed improvement when running the VCS on a CPU with multiple cores.